### PR TITLE
Add to HistogramConfiguration the property 'ExportAsVmRange'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,73 @@
+name: Build
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+env: []
+
+jobs:
+  build:
+    name: build
+    runs-on: windows-2019
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set Versiona
+        id: version
+        shell: pwsh
+        run: |
+          $runNumber = "${{ github.run_number }}"
+          $commitHash = "${{ github.sha }}"
+          $commitCount = (git rev-list --count HEAD)
+          $version = "1.1.$commitCount.$runNumber"
+          $asipath = "Prometheus/Prometheus.csproj"
+          echo "VERSION=$version" >> $env:GITHUB_ENV
+          echo "COMMIT=$commitHash" >> $env:GITHUB_ENV
+          (Get-Content "$asipath") -replace '0\.0\.0\.0', "$version" | Set-Content "$asipath"
+          (Get-Content "$asipath") -replace 'GIT_COMMIT', "$commitHash" | Set-Content "$asipath"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore prometheus-net.sln
+
+      - name: Build
+        run: dotnet build prometheus-net.sln --configuration Release --no-restore /p:ApplicationVersion=%VERSION%
+
+      - name: Publish artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: |
+            Prometheus/bin/Release/*.nupkg
+
+      - name: Collect artifacts
+        run: |
+          mkdir artifacts
+          cp Prometheus/bin/Release/*.nupkg artifacts/
+
+      - name: Draft release
+        if: github.ref == 'refs/heads/master'
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191  # v2.0.8
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: v${{ env.VERSION }}
+          tag_name: v${{ env.VERSION }}
+          target_commitish: ${{ github.sha }}
+          files: |
+            artifacts/*
+          draft: true
+

--- a/Prometheus/HistogramConfiguration.cs
+++ b/Prometheus/HistogramConfiguration.cs
@@ -14,4 +14,10 @@ public sealed class HistogramConfiguration : MetricConfiguration
     /// If null, inherits the exemplar behavior from the metric factory.
     /// </summary>
     public ExemplarBehavior? ExemplarBehavior { get; set; }
+
+    /// <summary>
+    /// Allows you to configure how the histogram is exported, using the vmrange label
+    /// instead of le label with cumulative values.
+    /// </summary>
+    public bool ExportAsVmRange { get; set; }
 }

--- a/Prometheus/MetricFactory.cs
+++ b/Prometheus/MetricFactory.cs
@@ -119,7 +119,7 @@ public sealed class MetricFactory : IMetricFactory
 
     private static Gauge CreateGaugeInstance(string Name, string Help, in StringSequence InstanceLabelNames, in LabelSequence StaticLabels, GaugeConfiguration Configuration, ExemplarBehavior ExemplarBehavior) => new(Name, Help, InstanceLabelNames, StaticLabels, Configuration.SuppressInitialValue, ExemplarBehavior);
 
-    private static Histogram CreateHistogramInstance(string Name, string Help, in StringSequence InstanceLabelNames, in LabelSequence StaticLabels, HistogramConfiguration Configuration, ExemplarBehavior ExemplarBehavior) => new(Name, Help, InstanceLabelNames, StaticLabels, Configuration.SuppressInitialValue, Configuration.Buckets, ExemplarBehavior);
+    private static Histogram CreateHistogramInstance(string Name, string Help, in StringSequence InstanceLabelNames, in LabelSequence StaticLabels, HistogramConfiguration Configuration, ExemplarBehavior ExemplarBehavior) => new(Name, Help, InstanceLabelNames, StaticLabels, Configuration.SuppressInitialValue, Configuration.Buckets, Configuration.ExportAsVmRange, ExemplarBehavior);
 
     private static Summary CreateSummaryInstance(string name, string help, in StringSequence instanceLabelNames, in LabelSequence staticLabels, SummaryConfiguration configuration, ExemplarBehavior exemplarBehavior) => new(name, help, instanceLabelNames, staticLabels, exemplarBehavior, configuration.SuppressInitialValue,
             configuration.Objectives, configuration.MaxAge, configuration.AgeBuckets, configuration.BufferSize);


### PR DESCRIPTION
If true, buckets will be exported/serialized using vmrange labels instead of le ones.